### PR TITLE
Updating doc with renamed env-var

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Create a `.env` file with the following configuration:
 DATABASE_URL="postgresql://username:password@localhost:5432/vectordb?schema=public"
 
 # API Configuration
-OPENAI_API_KEY="your-api-key-here"
+SERVER_API_KEY="your-api-key-here"
 
 # Server Configuration
 HOST="0.0.0.0"


### PR DESCRIPTION
From the doc, OPENAI_API_KEY were not respected. Looked into config.py, saw that the new env var is named SERVER_API_KEY, which upon testing works as expected.